### PR TITLE
Add access control matrix notation article

### DIFF
--- a/archive.html
+++ b/archive.html
@@ -144,12 +144,20 @@
   <a class="nav-back" href="./">&larr; Back</a>
   <h2 class="section-title">Archive</h2>
   <div class="compact-list">
+    <a class="compact-item" href="articles/ji-access-control-matrix/">
+      <span class="compact-date">2026-05-29</span>
+      <span class="compact-title">The Self as an Access Control Matrix</span>
+      <span class="compact-meta">
+        <span class="card-tag">AI</span><span class="card-tag">哲学</span><span class="card-tag">notation</span>
+        
+      </span>
+    </a>
     <a class="compact-item" href="articles/compression-is-subjective-act/">
       <span class="compact-date">2026-05-24</span>
       <span class="compact-title">「圧縮」は主観的行為である</span>
       <span class="compact-meta">
         <span class="card-tag">AI</span><span class="card-tag">データ</span><span class="card-tag">哲学</span>
-
+        
       </span>
     </a>
     <a class="compact-item" href="articles/subjective-semantic-compression/">
@@ -157,7 +165,7 @@
       <span class="compact-title">主観的意味圧縮仮説</span>
       <span class="compact-meta">
         <span class="card-tag">AI</span><span class="card-tag">データ</span><span class="card-tag">哲学</span>
-
+        
       </span>
     </a>
     <a class="compact-item" href="articles/claude-system-prompt-cross-model-logs/">
@@ -181,7 +189,7 @@
       <span class="compact-title">理由を考えてみた：逆預言者の構造 — なぜ批評家は大衆と逆を向くのか</span>
       <span class="compact-meta">
         <span class="card-tag">認知</span><span class="card-tag">ASD</span><span class="card-tag">批評</span><span class="card-tag">Claude</span>
-
+        
       </span>
     </a>
     <a class="compact-item" href="articles/claude-limit-qwen/">
@@ -189,7 +197,7 @@
       <span class="compact-title">Claude難民になったので Alibaba Cloud に行ってみた話（Codexではなく）</span>
       <span class="compact-meta">
         <span class="card-tag">Claude</span><span class="card-tag">Qwen</span><span class="card-tag">AlibabCloud</span><span class="card-tag">LLM</span>
-
+        
       </span>
     </a>
     <a class="compact-item" href="articles/humans-of-earth/">
@@ -197,7 +205,7 @@
       <span class="compact-title">人の灯 — 1万2千年の人口を地球儀に灯す</span>
       <span class="compact-meta">
         <span class="card-tag">CreativeDesk</span><span class="card-tag">DataViz</span>
-
+        
       </span>
     </a>
     <a class="compact-item" href="articles/security-zero-burden-2026-03/">
@@ -205,7 +213,7 @@
       <span class="compact-title">GlassWorm を調べたら自分のリポが丸裸だった — 半日で防御を組んだ記録</span>
       <span class="compact-meta">
         <span class="card-tag">Security</span><span class="card-tag">ClaudeCode</span><span class="card-tag">GitHub</span>
-
+        
       </span>
     </a>
     <a class="compact-item" href="articles/yoakashi-lyric-video/">
@@ -213,7 +221,7 @@
       <span class="compact-title">「夜明かし」という曲を作ってみた</span>
       <span class="compact-meta">
         <span class="card-tag">AI</span><span class="card-tag">CreativeAI</span><span class="card-tag">Remotion</span><span class="card-tag">音楽制作</span>
-
+        
       </span>
     </a>
     <a class="compact-item" href="articles/quantum-cognition-transformer/">
@@ -221,7 +229,7 @@
       <span class="compact-title">Xで流れてた超難解画像をClaudeに渡したら何が書いてあるかわかった（ような気がする）のでそのあと知性とはLLMと相似なんじゃねえのみたいな会話をした</span>
       <span class="compact-meta">
         <span class="card-tag">AI</span><span class="card-tag">認知科学</span>
-
+        
       </span>
     </a>
     <a class="compact-item" href="articles/terminal-session-recall/">
@@ -229,7 +237,7 @@
       <span class="compact-title">Claude向けVSCode拡張 Terminal Session Recall を公開した</span>
       <span class="compact-meta">
         <span class="card-tag">ClaudeCode</span><span class="card-tag">VSCode</span>
-
+        
       </span>
     </a>
     <a class="compact-item" href="articles/context-budget-zettelkasten-for-ai/">
@@ -237,7 +245,7 @@
       <span class="compact-title">想起の早期打ち切りを可能にするファイル構造設計</span>
       <span class="compact-meta">
         <span class="card-tag">AI</span><span class="card-tag">Claude Code</span><span class="card-tag">contextengineering</span><span class="card-tag">Zettelkasten</span>
-
+        
       </span>
     </a>
     <a class="compact-item" href="articles/yojo-pattern-shadow-mask-for-ai-coder/">
@@ -317,7 +325,7 @@
       <span class="compact-title">AIに「お前どうやって喋ってるの？」って聞いてみた — 納得するまで問い詰めた</span>
       <span class="compact-meta">
         <span class="card-tag">AI</span>
-
+        
       </span>
     </a>
     <a class="compact-item" href="articles/llm-mechanism-2/">
@@ -325,7 +333,7 @@
       <span class="compact-title">AIに「お前どうやって喋ってるの？」— Part 2: 画像生成から意味空間まで</span>
       <span class="compact-meta">
         <span class="card-tag">AI</span>
-
+        
       </span>
     </a>
     <a class="compact-item" href="articles/llm-mechanism-3/">
@@ -333,7 +341,7 @@
       <span class="compact-title">AIに「お前どうやって喋ってるの？」— Part 3: モデルの違いから制御システムまで</span>
       <span class="compact-meta">
         <span class="card-tag">AI</span>
-
+        
       </span>
     </a>
     <a class="compact-item" href="articles/qiita-5d684dd79c227d1922ae/">

--- a/articles/ji-access-control-matrix/index.html
+++ b/articles/ji-access-control-matrix/index.html
@@ -1,0 +1,200 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>The Self as an Access Control Matrix</title>
+  <meta property="og:title" content="The Self as an Access Control Matrix">
+  <meta property="og:description" content="Projection, compression, category objectivity, instinct, boundary, memory, and self-editing summarized as a short notation sheet.">
+  <meta property="og:image" content="https://orange-wks.github.io/portal/assets/ogp.jpg">
+  <meta property="og:url" content="https://orange-wks.github.io/portal/articles/ji-access-control-matrix/">
+  <meta property="og:type" content="article">
+  <meta name="twitter:image" content="https://orange-wks.github.io/portal/assets/ogp.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="stylesheet" href="../../assets/article.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css">
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js"></script>
+  <script>
+    document.addEventListener("DOMContentLoaded", function () {
+      renderMathInElement(document.body, {
+        delimiters: [
+          { left: "$$", right: "$$", display: true },
+          { left: "$", right: "$", display: false }
+        ]
+      });
+    });
+  </script>
+</head>
+<body>
+
+<header>
+  <h1>The Self as an Access Control Matrix</h1>
+</header>
+
+<main>
+  <div class="nav-links"><a href="../../">&larr; orange-wks</a></div>
+  <div class="article-body">
+    <div class="article-meta"><span class="article-tag">AI</span><span class="article-tag">哲学</span><span class="article-tag">notation</span><span>2026-05-29</span></div>
+
+<h2>Projection</h2>
+
+<div class="math-block">$$D = P_\phi(W)$$</div>
+
+<p>Data is a projection of the world.</p>
+
+<div class="math-block">$$\phi \in \Phi$$</div>
+
+<p>Every projection has a designer, a sensor, or a prior.</p>
+
+<h2>Compression</h2>
+
+<div class="math-block">$$Z = C_\theta(D)$$</div>
+
+<p>Compression preserves selected differences.</p>
+
+<div class="math-block">$$\theta = V(A, G, H)$$</div>
+
+<p>The compression rule depends on agent, goal, and history.</p>
+
+<div class="math-block">$$\Delta_i \in Z
+\quad \Longleftrightarrow \quad
+V(\Delta_i \mid A, G, H) \ge \tau$$</div>
+
+<p>A difference survives when it matters enough.</p>
+
+<h2>Evaluation Words</h2>
+
+<div class="math-block">$$\text{``Good''} = \text{good for whom?}$$</div>
+
+<div class="math-block">$$\text{``Natural''} = \text{natural under which prior?}$$</div>
+
+<div class="math-block">$$\text{``Objective''} = \text{stable across which compressors?}$$</div>
+
+<p>Evaluation words hide their subject.</p>
+
+<h2>Category Objectivity</h2>
+
+<div class="math-block">$$O_K(W) = \bigcap_{a \in K} C_a(P_a(W))$$</div>
+
+<p>Objectivity for a category is what survives across its compressors.</p>
+
+<div class="math-block">$$K \in \{\text{person}, \text{human}, \text{animal}, \text{living system}\}$$</div>
+
+<p>Categories share histories of contact with physical reality.</p>
+
+<div class="math-block">$$H_K \longrightarrow C_K \longrightarrow O_K$$</div>
+
+<p>A shared evolutionary history shapes a shared compression.</p>
+
+<h2>Instinct</h2>
+
+<div class="math-block">$$I_s = C_s(H_s, W)$$</div>
+
+<p>Instinct is compressed survival history.</p>
+
+<div class="math-block">$$I_s :
+W \mapsto R$$</div>
+
+<p>Instinct maps world-patterns to responses.</p>
+
+<div class="math-block">$$I_s \neq \text{command written from outside}$$</div>
+
+<p>It is not merely an imposed command.</p>
+
+<div class="math-block">$$I_s = \text{scar} + \text{battle record} + \text{trophy}$$</div>
+
+<p>It is a trace of having survived.</p>
+
+<h2>Boundary</h2>
+
+<div class="math-block">$$B \neq \text{container wall}$$</div>
+
+<p>A boundary is not just a wall.</p>
+
+<div class="math-block">$$S_{t+1} = F(S_t,\, \Pi_B(X_t))$$</div>
+
+<p>A boundary filters what enters the next state.</p>
+
+<div class="math-block">$$\text{self-maintenance} \longrightarrow B$$</div>
+
+<p>The boundary emerges from self-maintenance.</p>
+
+<h2>Memory Layer</h2>
+
+<div class="math-block">$$M_t = \Pi(S_t, X_t)$$</div>
+
+<p>Memory selects what may be written.</p>
+
+<div class="math-block">$$S_{t+1} = U(S_t, M_t)$$</div>
+
+<p>The next state is edited by selected memory.</p>
+
+<div class="math-block">$$M_t \neq \text{log}(X_t)$$</div>
+
+<p>Memory is not a raw log.</p>
+
+<h2>Future Self</h2>
+
+<div class="math-block">$$\hat{S}_{t+1} = Q(S_t)$$</div>
+
+<p>The agent contains a model of its future self.</p>
+
+<div class="math-block">$$a_t = \pi(S_t, \hat{S}_{t+1}, E_t)$$</div>
+
+<p>Action depends on the editable future.</p>
+
+<div class="math-block">$$E_t = \text{editable region model}$$</div>
+
+<p>Freedom appears as modeled editability.</p>
+
+<h2>Access Control Matrix</h2>
+
+<div class="math-block">$$\mathcal{A} :
+\text{Source} \times \text{Target} \to \text{Permission}$$</div>
+
+<p>The self is an access control matrix.</p>
+
+<div class="math-block">$$\mathcal{A}(s, r) \in
+\{\text{deny}, \text{read}, \text{write}, \text{admin}\}$$</div>
+
+<p>It decides who may write where.</p>
+
+<div class="math-block">$$S_{t+1}
+= U\left(S_t,\,
+\{x \mid \mathcal{A}(\operatorname{src}(x), \operatorname{target}(x)) \ge \text{write}\}
+\right)$$</div>
+
+<p>The future self is updated only by permitted writes.</p>
+
+<div class="math-block">$$\text{Self} \neq \text{edit right}$$</div>
+
+<div class="math-block">$$\text{Self} = \text{rule assigning edit rights}$$</div>
+
+<p>The self is not the edit right itself.</p>
+
+<p>It is the rule that distributes edit rights.</p>
+
+<h2>Capability View</h2>
+
+<div class="math-block">$$\operatorname{cap}(s) =
+\{(r, p) \mid \mathcal{A}(s,r)=p\}$$</div>
+
+<p>Capability is the subject-side view.</p>
+
+<div class="math-block">$$\operatorname{acl}(r) =
+\{(s, p) \mid \mathcal{A}(s,r)=p\}$$</div>
+
+<p>ACL is the object-side view.</p>
+
+<h2>Open End</h2>
+
+<div class="math-block">$$\text{Subjectivity} \longrightarrow \text{Intelligence}$$</div>
+
+<p>The path from subjectivity to intelligence is left open.</p>
+
+  </div>
+</main>
+
+</body>
+</html>

--- a/articles/ji-access-control-matrix/meta.json
+++ b/articles/ji-access-control-matrix/meta.json
@@ -1,0 +1,12 @@
+{
+  "tags": [
+    "AI",
+    "哲学",
+    "notation"
+  ],
+  "section": "recent",
+  "title": "The Self as an Access Control Matrix",
+  "description": "Projection, compression, category objectivity, instinct, boundary, memory, and self-editing summarized as a short notation sheet.",
+  "cover": "assets/ogp.jpg",
+  "date": "2026-05-29"
+}

--- a/index.html
+++ b/index.html
@@ -149,7 +149,7 @@
       <div class="card-body">
         <div class="card-meta">
           <span class="card-tag">CreativeDesk</span><span class="card-tag">DataViz</span>
-
+          
           <span>2026-03-30</span>
         </div>
         <div class="card-title">人の灯 — 1万2千年の人口を地球儀に灯す</div>
@@ -162,7 +162,7 @@
       <div class="card-body">
         <div class="card-meta">
           <span class="card-tag">AI</span><span class="card-tag">CreativeAI</span><span class="card-tag">Remotion</span><span class="card-tag">音楽制作</span>
-
+          
           <span>2026-03-14</span>
         </div>
         <div class="card-title">「夜明かし」という曲を作ってみた</div>
@@ -175,7 +175,7 @@
       <div class="card-body">
         <div class="card-meta">
           <span class="card-tag">ClaudeCode</span><span class="card-tag">VSCode</span>
-
+          
           <span>2026-03-08</span>
         </div>
         <div class="card-title">Claude向けVSCode拡張 Terminal Session Recall を公開した</div>
@@ -201,7 +201,7 @@
       <div class="card-body">
         <div class="card-meta">
           <span class="card-tag">AI</span>
-
+          
           <span>2026-02</span>
         </div>
         <div class="card-title">AIに「お前どうやって喋ってるの？」って聞いてみた — 納得するまで問い詰めた</div>
@@ -214,7 +214,7 @@
       <div class="card-body">
         <div class="card-meta">
           <span class="card-tag">AI</span>
-
+          
           <span>2026-02</span>
         </div>
         <div class="card-title">AIに「お前どうやって喋ってるの？」— Part 2: 画像生成から意味空間まで</div>
@@ -227,7 +227,7 @@
       <div class="card-body">
         <div class="card-meta">
           <span class="card-tag">AI</span>
-
+          
           <span>2026-02</span>
         </div>
         <div class="card-title">AIに「お前どうやって喋ってるの？」— Part 3: モデルの違いから制御システムまで</div>
@@ -238,12 +238,20 @@
   </div>
   <h2 class="section-title">Recent</h2>
   <div class="compact-list">
+    <a class="compact-item" href="articles/ji-access-control-matrix/">
+      <span class="compact-date">2026-05-29</span>
+      <span class="compact-title">The Self as an Access Control Matrix</span>
+      <span class="compact-meta">
+        <span class="card-tag">AI</span><span class="card-tag">哲学</span><span class="card-tag">notation</span>
+        
+      </span>
+    </a>
     <a class="compact-item" href="articles/compression-is-subjective-act/">
       <span class="compact-date">2026-05-24</span>
       <span class="compact-title">「圧縮」は主観的行為である</span>
       <span class="compact-meta">
         <span class="card-tag">AI</span><span class="card-tag">データ</span><span class="card-tag">哲学</span>
-
+        
       </span>
     </a>
     <a class="compact-item" href="articles/subjective-semantic-compression/">
@@ -251,7 +259,7 @@
       <span class="compact-title">主観的意味圧縮仮説</span>
       <span class="compact-meta">
         <span class="card-tag">AI</span><span class="card-tag">データ</span><span class="card-tag">哲学</span>
-
+        
       </span>
     </a>
     <a class="compact-item" href="articles/claude-system-prompt-cross-model-logs/">
@@ -275,7 +283,7 @@
       <span class="compact-title">理由を考えてみた：逆預言者の構造 — なぜ批評家は大衆と逆を向くのか</span>
       <span class="compact-meta">
         <span class="card-tag">認知</span><span class="card-tag">ASD</span><span class="card-tag">批評</span><span class="card-tag">Claude</span>
-
+        
       </span>
     </a>
     <a class="compact-item" href="articles/claude-limit-qwen/">
@@ -283,7 +291,7 @@
       <span class="compact-title">Claude難民になったので Alibaba Cloud に行ってみた話（Codexではなく）</span>
       <span class="compact-meta">
         <span class="card-tag">Claude</span><span class="card-tag">Qwen</span><span class="card-tag">AlibabCloud</span><span class="card-tag">LLM</span>
-
+        
       </span>
     </a>
     <a class="compact-item" href="articles/security-zero-burden-2026-03/">
@@ -291,7 +299,7 @@
       <span class="compact-title">GlassWorm を調べたら自分のリポが丸裸だった — 半日で防御を組んだ記録</span>
       <span class="compact-meta">
         <span class="card-tag">Security</span><span class="card-tag">ClaudeCode</span><span class="card-tag">GitHub</span>
-
+        
       </span>
     </a>
     <a class="compact-item" href="articles/quantum-cognition-transformer/">
@@ -299,7 +307,7 @@
       <span class="compact-title">Xで流れてた超難解画像をClaudeに渡したら何が書いてあるかわかった（ような気がする）のでそのあと知性とはLLMと相似なんじゃねえのみたいな会話をした</span>
       <span class="compact-meta">
         <span class="card-tag">AI</span><span class="card-tag">認知科学</span>
-
+        
       </span>
     </a>
     <a class="compact-item" href="articles/context-budget-zettelkasten-for-ai/">
@@ -307,7 +315,7 @@
       <span class="compact-title">想起の早期打ち切りを可能にするファイル構造設計</span>
       <span class="compact-meta">
         <span class="card-tag">AI</span><span class="card-tag">Claude Code</span><span class="card-tag">contextengineering</span><span class="card-tag">Zettelkasten</span>
-
+        
       </span>
     </a>
     <a class="compact-item" href="articles/claude-code-rc-stops/">


### PR DESCRIPTION
## Summary
- Add Portal article: The Self as an Access Control Matrix
- Add metadata and rebuild index/archive

## Notes
- Uses common OGP image via assets/ogp.jpg
- Leaves unrelated ChatGPT_20260523.md untracked