### PR TITLE
Simplify access control matrix article as scientific plate

### DIFF
--- a/articles/ji-access-control-matrix/index.html
+++ b/articles/ji-access-control-matrix/index.html
@@ -1,17 +1,16 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>The Self as an Access Control Matrix</title>
   <meta property="og:title" content="The Self as an Access Control Matrix">
-  <meta property="og:description" content="Projection, compression, category objectivity, instinct, boundary, memory, and self-editing summarized as a short notation sheet.">
+  <meta property="og:description" content="A small notation plate for projection, compression, category objectivity, instinct, boundary, memory, and future self-editing.">
   <meta property="og:image" content="https://orange-wks.github.io/portal/assets/ogp.jpg">
   <meta property="og:url" content="https://orange-wks.github.io/portal/articles/ji-access-control-matrix/">
   <meta property="og:type" content="article">
   <meta name="twitter:image" content="https://orange-wks.github.io/portal/assets/ogp.jpg">
   <meta name="twitter:card" content="summary_large_image">
-  <link rel="stylesheet" href="../../assets/article.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css">
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js"></script>
@@ -26,419 +25,356 @@
     });
   </script>
   <style>
-    .article-body {
+    :root {
+      --paper: #f5f0e6;
+      --ink: #1f1d19;
+      --faint: #7c7367;
+      --rule: #cbbda7;
+      --accent: #b95f2b;
+      --wash: #eadfce;
+    }
+    * {
+      box-sizing: border-box;
+    }
+    body {
+      margin: 0;
+      background: #d9d0c2;
+      color: var(--ink);
+      font-family: Georgia, "Times New Roman", serif;
+    }
+    .page {
       max-width: 980px;
-    }
-    .notation-hero {
-      border: 1px solid rgba(232, 98, 42, 0.28);
-      border-radius: 8px;
-      padding: 1.4rem;
-      margin: 1.8rem 0 2rem;
+      margin: 32px auto;
+      padding: 56px 62px 64px;
       background:
-        linear-gradient(135deg, rgba(232, 98, 42, 0.09), rgba(255, 255, 255, 0) 42%),
-        linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(249, 249, 247, 0.92));
+        linear-gradient(rgba(255, 255, 255, 0.34), rgba(255, 255, 255, 0.08)),
+        var(--paper);
+      border: 1px solid #b9aa94;
+      box-shadow: 0 24px 70px rgba(44, 35, 24, 0.22);
     }
-    .notation-hero__label {
-      color: #e8622a;
-      font-size: 0.76rem;
-      font-weight: 700;
-      letter-spacing: 0.08em;
+    .back {
+      display: inline-block;
+      margin: 0 0 26px;
+      color: var(--faint);
+      font-size: 13px;
+      text-decoration: none;
+    }
+    .back:hover {
+      color: var(--accent);
+    }
+    .plate-number {
+      text-align: center;
+      color: var(--faint);
+      font-size: 12px;
+      letter-spacing: 0.16em;
       text-transform: uppercase;
     }
-    .notation-hero__title {
-      margin: 0.45rem 0 0.4rem;
-      color: #1a1a1a;
-      font-size: clamp(1.35rem, 4vw, 2.2rem);
-      line-height: 1.15;
+    h1 {
+      margin: 18px auto 10px;
+      max-width: 760px;
+      text-align: center;
+      font-size: clamp(30px, 5vw, 54px);
+      font-weight: 400;
+      line-height: 1.02;
+      letter-spacing: 0.01em;
     }
-    .notation-hero__copy {
-      max-width: 42rem;
-      margin: 0;
-      color: #555;
-      line-height: 1.65;
+    .subtitle {
+      max-width: 620px;
+      margin: 0 auto 30px;
+      text-align: center;
+      color: var(--faint);
+      font-size: 15px;
+      line-height: 1.7;
     }
-    .notation-flow {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.45rem;
-      margin-top: 1rem;
-      color: #333;
-      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-      font-size: 0.82rem;
+    .rule {
+      height: 1px;
+      margin: 24px 0 30px;
+      background: linear-gradient(90deg, transparent, var(--rule), transparent);
     }
-    .notation-flow span {
-      border: 1px solid rgba(26, 26, 26, 0.12);
-      border-radius: 999px;
-      padding: 0.28rem 0.58rem;
-      background: rgba(255, 255, 255, 0.7);
-    }
-    .notation-grid {
+    .axioms {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-      gap: 1rem;
-      margin: 1.4rem 0 2rem;
+      grid-template-columns: 1fr;
+      gap: 18px;
+      margin: 0 auto 34px;
+      max-width: 760px;
     }
-    .notation-card {
-      border: 1px solid rgba(26, 26, 26, 0.1);
-      border-radius: 8px;
-      padding: 1rem;
-      background: #fff;
-      box-shadow: 0 10px 30px rgba(26, 26, 26, 0.05);
+    .axiom {
+      display: grid;
+      grid-template-columns: 44px 1fr;
+      gap: 16px;
+      align-items: start;
     }
-    .notation-card--wide {
-      grid-column: 1 / -1;
+    .mark {
+      color: var(--accent);
+      font-size: 12px;
+      letter-spacing: 0.1em;
+      padding-top: 8px;
+      text-transform: uppercase;
     }
-    .notation-card h2 {
-      margin: 0 0 0.85rem;
-      padding: 0;
-      border: 0;
-      color: #1a1a1a;
-      font-size: 0.95rem;
-      letter-spacing: 0.02em;
+    .statement {
+      border-left: 1px solid var(--rule);
+      padding-left: 18px;
     }
-    .notation-card p {
-      margin: 0.55rem 0 0;
-      color: #555;
-      font-size: 0.92rem;
+    .statement .math {
+      margin: 0;
+      font-size: 20px;
+    }
+    .statement p {
+      margin: 8px 0 0;
+      color: var(--faint);
+      font-size: 14px;
       line-height: 1.55;
     }
-    .notation-card .math-block {
-      margin: 0.65rem 0;
-      padding: 0.7rem 0.75rem;
-      overflow-x: auto;
-      border-radius: 6px;
-      background: #f8f6f2;
-      border: 1px solid rgba(26, 26, 26, 0.07);
+    .matrix-section {
+      margin: 38px auto;
+      padding: 28px;
+      border: 1px solid var(--rule);
+      background: rgba(255, 255, 255, 0.22);
     }
-    .matrix-wrap {
-      overflow-x: auto;
-      margin: 0.8rem 0 0;
+    .matrix-title {
+      display: flex;
+      justify-content: space-between;
+      gap: 16px;
+      align-items: baseline;
+      margin-bottom: 18px;
+      border-bottom: 1px solid var(--rule);
+      padding-bottom: 10px;
     }
-    .matrix {
-      min-width: 680px;
+    .matrix-title h2 {
+      margin: 0;
+      font-size: 21px;
+      font-weight: 400;
+      letter-spacing: 0.04em;
+    }
+    .matrix-title span {
+      color: var(--faint);
+      font-size: 12px;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      white-space: nowrap;
+    }
+    table {
       width: 100%;
       border-collapse: collapse;
-      font-size: 0.86rem;
+      font-size: 14px;
     }
-    .matrix th,
-    .matrix td {
-      border: 1px solid rgba(26, 26, 26, 0.11);
-      padding: 0.55rem 0.65rem;
+    th,
+    td {
+      border-bottom: 1px solid rgba(203, 189, 167, 0.82);
+      padding: 11px 10px;
       text-align: center;
-      vertical-align: middle;
     }
-    .matrix th {
-      background: #f3eee7;
-      color: #333;
-      font-weight: 700;
+    th {
+      color: var(--faint);
+      font-size: 11px;
+      font-weight: 400;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
     }
-    .matrix td:first-child {
-      color: #333;
-      font-weight: 700;
+    td:first-child,
+    th:first-child {
       text-align: left;
-      background: #fbfaf7;
     }
-    .perm-write { color: #9a4a12; font-weight: 700; }
-    .perm-admin { color: #255f46; font-weight: 700; }
-    .perm-deny { color: #9d2f2f; font-weight: 700; }
-    .perm-muted { color: #aaa; }
-    @media (prefers-color-scheme: dark) {
-      .notation-hero {
-        background:
-          linear-gradient(135deg, rgba(232, 98, 42, 0.16), rgba(34, 34, 34, 0) 42%),
-          linear-gradient(180deg, rgba(34, 34, 34, 0.96), rgba(26, 26, 26, 0.96));
+    td:first-child {
+      color: var(--ink);
+      font-style: italic;
+    }
+    .write {
+      color: #8b4a20;
+      font-weight: 700;
+    }
+    .deny {
+      color: #8d2f29;
+      font-weight: 700;
+    }
+    .admin {
+      color: #2f6547;
+      font-weight: 700;
+    }
+    .empty {
+      color: #b7aa98;
+    }
+    .caption {
+      margin: 18px 0 0;
+      color: var(--faint);
+      font-size: 13px;
+      line-height: 1.65;
+    }
+    .closing {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 24px;
+      margin-top: 34px;
+    }
+    .closing-box {
+      border-top: 1px solid var(--rule);
+      padding-top: 16px;
+    }
+    .closing-box .math {
+      font-size: 18px;
+      margin: 0;
+    }
+    .closing-box p {
+      margin: 9px 0 0;
+      color: var(--faint);
+      font-size: 13px;
+      line-height: 1.55;
+    }
+    .footer-note {
+      margin-top: 42px;
+      text-align: center;
+      color: var(--faint);
+      font-size: 12px;
+      letter-spacing: 0.08em;
+    }
+    @media (max-width: 720px) {
+      .page {
+        margin: 0;
+        padding: 36px 22px 42px;
+        border-left: 0;
+        border-right: 0;
       }
-      .notation-hero__title { color: #f1f1f1; }
-      .notation-hero__copy,
-      .notation-card p { color: #c9c9c9; }
-      .notation-flow { color: #ddd; }
-      .notation-flow span,
-      .notation-card {
-        background: #222;
-        border-color: #333;
+      .axiom {
+        grid-template-columns: 1fr;
+        gap: 6px;
       }
-      .notation-card h2 { color: #f1f1f1; }
-      .notation-card .math-block {
-        background: #181818;
-        border-color: #333;
+      .statement {
+        padding-left: 14px;
       }
-      .matrix th,
-      .matrix td { border-color: #3a3a3a; }
-      .matrix th { background: #2c2823; color: #eee; }
-      .matrix td:first-child { background: #202020; color: #eee; }
-      .perm-write { color: #f1a15d; }
-      .perm-admin { color: #80c7a2; }
-      .perm-deny { color: #ef8a8a; }
+      .matrix-section {
+        padding: 18px;
+        overflow-x: auto;
+      }
+      table {
+        min-width: 620px;
+      }
+      .closing {
+        grid-template-columns: 1fr;
+      }
     }
   </style>
 </head>
 <body>
+  <main class="page">
+    <a class="back" href="../../">&larr; orange-wks</a>
+    <div class="plate-number">Plate I / notes toward a theory of self</div>
+    <h1>The Self as an Access Control Matrix</h1>
+    <p class="subtitle">A small notation sheet for projection, compression, category objectivity, instinct, boundary, memory, and future self-editing.</p>
 
-<header>
-  <h1>The Self as an Access Control Matrix</h1>
-</header>
+    <div class="rule"></div>
 
-<main>
-  <div class="nav-links"><a href="../../">&larr; orange-wks</a></div>
-  <div class="article-body">
-    <div class="article-meta"><span class="article-tag">AI</span><span class="article-tag">哲学</span><span class="article-tag">notation</span><span>2026-05-29</span></div>
+    <section class="axioms" aria-label="Core notation">
+      <div class="axiom">
+        <div class="mark">I</div>
+        <div class="statement">
+          <div class="math">$$D = P_\phi(W)$$</div>
+          <p>Data is not the world. It is a projection made through a sensor, a prior, or a designer.</p>
+        </div>
+      </div>
 
-    <section class="notation-hero">
-      <div class="notation-hero__label">notation sheet</div>
-      <h2 class="notation-hero__title">The Self as an Access Control Matrix</h2>
-      <p class="notation-hero__copy">Projection, compression, category objectivity, instinct, boundary, memory, and self-editing compressed into a small set of formulas.</p>
-      <div class="notation-flow">
-        <span>World</span>
-        <span>Projection</span>
-        <span>Compression</span>
-        <span>Boundary</span>
-        <span>Memory</span>
-        <span>Future Self</span>
-        <span>Access Control Matrix</span>
+      <div class="axiom">
+        <div class="mark">II</div>
+        <div class="statement">
+          <div class="math">$$Z = C_\theta(D)$$</div>
+          <p>Compression preserves selected differences. A difference survives when it matters enough.</p>
+        </div>
+      </div>
+
+      <div class="axiom">
+        <div class="mark">III</div>
+        <div class="statement">
+          <div class="math">$$O_K(W) = \bigcap_{a \in K} C_a(P_a(W))$$</div>
+          <p>Objectivity for a category is what survives across its compressors.</p>
+        </div>
+      </div>
+
+      <div class="axiom">
+        <div class="mark">IV</div>
+        <div class="statement">
+          <div class="math">$$S_{t+1} = F(S_t,\, \Pi_B(X_t))$$</div>
+          <p>A boundary is not merely a wall. It filters what may enter the next state.</p>
+        </div>
       </div>
     </section>
 
-    <section class="notation-grid">
-
-<article class="notation-card">
-<h2>Projection</h2>
-
-<div class="math-block">$$D = P_\phi(W)$$</div>
-
-<p>Data is a projection of the world.</p>
-
-<div class="math-block">$$\phi \in \Phi$$</div>
-
-<p>Every projection has a designer, a sensor, or a prior.</p>
-</article>
-
-<article class="notation-card">
-<h2>Compression</h2>
-
-<div class="math-block">$$Z = C_\theta(D)$$</div>
-
-<p>Compression preserves selected differences.</p>
-
-<div class="math-block">$$\theta = V(A, G, H)$$</div>
-
-<p>The compression rule depends on agent, goal, and history.</p>
-
-<div class="math-block">$$\Delta_i \in Z
-\quad \Longleftrightarrow \quad
-V(\Delta_i \mid A, G, H) \ge \tau$$</div>
-
-<p>A difference survives when it matters enough.</p>
-</article>
-
-<article class="notation-card">
-<h2>Evaluation Words</h2>
-
-<div class="math-block">$$\text{``Good''} = \text{good for whom?}$$</div>
-
-<div class="math-block">$$\text{``Natural''} = \text{natural under which prior?}$$</div>
-
-<div class="math-block">$$\text{``Objective''} = \text{stable across which compressors?}$$</div>
-
-<p>Evaluation words hide their subject.</p>
-</article>
-
-<article class="notation-card">
-<h2>Category Objectivity</h2>
-
-<div class="math-block">$$O_K(W) = \bigcap_{a \in K} C_a(P_a(W))$$</div>
-
-<p>Objectivity for a category is what survives across its compressors.</p>
-
-<div class="math-block">$$K \in \{\text{person}, \text{human}, \text{animal}, \text{living system}\}$$</div>
-
-<p>Categories share histories of contact with physical reality.</p>
-
-<div class="math-block">$$H_K \longrightarrow C_K \longrightarrow O_K$$</div>
-
-<p>A shared evolutionary history shapes a shared compression.</p>
-</article>
-
-<article class="notation-card">
-<h2>Instinct</h2>
-
-<div class="math-block">$$I_s = C_s(H_s, W)$$</div>
-
-<p>Instinct is compressed survival history.</p>
-
-<div class="math-block">$$I_s :
-W \mapsto R$$</div>
-
-<p>Instinct maps world-patterns to responses.</p>
-
-<div class="math-block">$$I_s \neq \text{command written from outside}$$</div>
-
-<p>It is not merely an imposed command.</p>
-
-<div class="math-block">$$I_s = \text{scar} + \text{battle record} + \text{trophy}$$</div>
-
-<p>It is a trace of having survived.</p>
-</article>
-
-<article class="notation-card">
-<h2>Boundary</h2>
-
-<div class="math-block">$$B \neq \text{container wall}$$</div>
-
-<p>A boundary is not just a wall.</p>
-
-<div class="math-block">$$S_{t+1} = F(S_t,\, \Pi_B(X_t))$$</div>
-
-<p>A boundary filters what enters the next state.</p>
-
-<div class="math-block">$$\text{self-maintenance} \longrightarrow B$$</div>
-
-<p>The boundary emerges from self-maintenance.</p>
-</article>
-
-<article class="notation-card">
-<h2>Memory Layer</h2>
-
-<div class="math-block">$$M_t = \Pi(S_t, X_t)$$</div>
-
-<p>Memory selects what may be written.</p>
-
-<div class="math-block">$$S_{t+1} = U(S_t, M_t)$$</div>
-
-<p>The next state is edited by selected memory.</p>
-
-<div class="math-block">$$M_t \neq \text{log}(X_t)$$</div>
-
-<p>Memory is not a raw log.</p>
-</article>
-
-<article class="notation-card">
-<h2>Future Self</h2>
-
-<div class="math-block">$$\hat{S}_{t+1} = Q(S_t)$$</div>
-
-<p>The agent contains a model of its future self.</p>
-
-<div class="math-block">$$a_t = \pi(S_t, \hat{S}_{t+1}, E_t)$$</div>
-
-<p>Action depends on the editable future.</p>
-
-<div class="math-block">$$E_t = \text{editable region model}$$</div>
-
-<p>Freedom appears as modeled editability.</p>
-</article>
-
-<article class="notation-card notation-card--wide">
-<h2>Access Control Matrix</h2>
-
-<div class="math-block">$$\mathcal{A} :
-\text{Source} \times \text{Target} \to \text{Permission}$$</div>
-
-<p>The self is an access control matrix.</p>
-
-<div class="math-block">$$\mathcal{A}(s, r) \in
-\{\text{deny}, \text{read}, \text{write}, \text{admin}\}$$</div>
-
-<p>It decides who may write where.</p>
-
-<div class="matrix-wrap" aria-label="Example access control matrix">
-  <table class="matrix">
-    <thead>
-      <tr>
-        <th>Source</th>
-        <th>Habit</th>
-        <th>Value</th>
-        <th>Moral</th>
-        <th>Desire</th>
-        <th>Admin</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>parent</td>
-        <td class="perm-write">write</td>
-        <td class="perm-write">write</td>
-        <td class="perm-muted">-</td>
-        <td class="perm-muted">-</td>
-        <td class="perm-muted">-</td>
-      </tr>
-      <tr>
-        <td>friend</td>
-        <td class="perm-muted">-</td>
-        <td class="perm-write">write</td>
-        <td class="perm-muted">-</td>
-        <td class="perm-muted">-</td>
-        <td class="perm-muted">-</td>
-      </tr>
-      <tr>
-        <td>religion</td>
-        <td class="perm-muted">-</td>
-        <td class="perm-write">write</td>
-        <td class="perm-write">write</td>
-        <td class="perm-muted">-</td>
-        <td class="perm-muted">-</td>
-      </tr>
-      <tr>
-        <td>ad</td>
-        <td class="perm-deny">deny</td>
-        <td class="perm-deny">deny</td>
-        <td class="perm-muted">-</td>
-        <td class="perm-deny">deny</td>
-        <td class="perm-muted">-</td>
-      </tr>
-      <tr>
-        <td>self</td>
-        <td class="perm-admin">admin</td>
-        <td class="perm-admin">admin</td>
-        <td class="perm-admin">admin</td>
-        <td class="perm-admin">admin</td>
-        <td class="perm-admin">admin</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-
-<div class="math-block">$$S_{t+1}
-= U\left(S_t,\,
-\{x \mid \mathcal{A}(\operatorname{src}(x), \operatorname{target}(x)) \ge \text{write}\}
-\right)$$</div>
-
-<p>The future self is updated only by permitted writes.</p>
-
-<div class="math-block">$$\text{Self} \neq \text{edit right}$$</div>
-
-<div class="math-block">$$\text{Self} = \text{rule assigning edit rights}$$</div>
-
-<p>The self is not the edit right itself.</p>
-
-<p>It is the rule that distributes edit rights.</p>
-</article>
-
-<article class="notation-card">
-<h2>Capability View</h2>
-
-<div class="math-block">$$\operatorname{cap}(s) =
-\{(r, p) \mid \mathcal{A}(s,r)=p\}$$</div>
-
-<p>Capability is the subject-side view.</p>
-
-<div class="math-block">$$\operatorname{acl}(r) =
-\{(s, p) \mid \mathcal{A}(s,r)=p\}$$</div>
-
-<p>ACL is the object-side view.</p>
-</article>
-
-<article class="notation-card">
-<h2>Open End</h2>
-
-<div class="math-block">$$\text{Subjectivity} \longrightarrow \text{Intelligence}$$</div>
-
-<p>The path from subjectivity to intelligence is left open.</p>
-</article>
-
+    <section class="matrix-section" aria-label="Access control matrix">
+      <div class="matrix-title">
+        <h2>Access Control Matrix</h2>
+        <span>who may write where</span>
+      </div>
+
+      <div class="math">$$\mathcal{A} : \text{Source} \times \text{Target} \to \text{Permission}$$</div>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Source</th>
+            <th>Habit</th>
+            <th>Value</th>
+            <th>Moral</th>
+            <th>Desire</th>
+            <th>Admin</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>parent</td>
+            <td class="write">write</td>
+            <td class="write">write</td>
+            <td class="empty">-</td>
+            <td class="empty">-</td>
+            <td class="empty">-</td>
+          </tr>
+          <tr>
+            <td>friend</td>
+            <td class="empty">-</td>
+            <td class="write">write</td>
+            <td class="empty">-</td>
+            <td class="empty">-</td>
+            <td class="empty">-</td>
+          </tr>
+          <tr>
+            <td>religion</td>
+            <td class="empty">-</td>
+            <td class="write">write</td>
+            <td class="write">write</td>
+            <td class="empty">-</td>
+            <td class="empty">-</td>
+          </tr>
+          <tr>
+            <td>ad</td>
+            <td class="deny">deny</td>
+            <td class="deny">deny</td>
+            <td class="empty">-</td>
+            <td class="deny">deny</td>
+            <td class="empty">-</td>
+          </tr>
+          <tr>
+            <td>self</td>
+            <td class="admin">admin</td>
+            <td class="admin">admin</td>
+            <td class="admin">admin</td>
+            <td class="admin">admin</td>
+            <td class="admin">admin</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p class="caption">The self is not the edit right itself. It is the rule that distributes edit rights.</p>
     </section>
 
-  </div>
-</main>
+    <section class="closing">
+      <div class="closing-box">
+        <div class="math">$$\operatorname{cap}(s) = \{(r,p) \mid \mathcal{A}(s,r)=p\}$$</div>
+        <p>Capability is the subject-side view.</p>
+      </div>
+      <div class="closing-box">
+        <div class="math">$$\operatorname{acl}(r) = \{(s,p) \mid \mathcal{A}(s,r)=p\}$$</div>
+        <p>ACL is the object-side view.</p>
+      </div>
+    </section>
 
+    <div class="footer-note">Subjectivity &rarr; Intelligence remains open.</div>
+  </main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Replace the card-heavy notation page with a simpler scientific-plate layout
- Center the access control matrix as the main visual element
- Keep the page self-contained and preserve KaTeX rendering

## Verification
- Checked title/meta and key plate markers in generated HTML
- Browser screenshot check remains unavailable because Chrome DevTools cannot connect