### PR TITLE
Add Japanese access control matrix plate

### DIFF
--- a/archive.html
+++ b/archive.html
@@ -152,6 +152,14 @@
         
       </span>
     </a>
+    <a class="compact-item" href="articles/ji-access-control-matrix-ja/">
+      <span class="compact-date">2026-05-29</span>
+      <span class="compact-title">自己とは、編集権を配る規則である</span>
+      <span class="compact-meta">
+        <span class="card-tag">AI</span><span class="card-tag">哲学</span><span class="card-tag">notation</span>
+        
+      </span>
+    </a>
     <a class="compact-item" href="articles/compression-is-subjective-act/">
       <span class="compact-date">2026-05-24</span>
       <span class="compact-title">「圧縮」は主観的行為である</span>

--- a/articles/ji-access-control-matrix-ja/index.html
+++ b/articles/ji-access-control-matrix-ja/index.html
@@ -1,0 +1,356 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>自己とは、編集権を配る規則である</title>
+  <meta property="og:title" content="自己とは、編集権を配る規則である">
+  <meta property="og:description" content="自己を Access Control Matrix として眺めるための、短い数式図版。">
+  <meta property="og:image" content="https://orange-wks.github.io/portal/assets/ogp.jpg">
+  <meta property="og:url" content="https://orange-wks.github.io/portal/articles/ji-access-control-matrix-ja/">
+  <meta property="og:type" content="article">
+  <meta name="twitter:image" content="https://orange-wks.github.io/portal/assets/ogp.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css">
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js"></script>
+  <script>
+    document.addEventListener("DOMContentLoaded", function () {
+      renderMathInElement(document.body, {
+        delimiters: [
+          { left: "$$", right: "$$", display: true },
+          { left: "$", right: "$", display: false }
+        ]
+      });
+    });
+  </script>
+  <style>
+    :root {
+      --paper: #f5f0e6;
+      --ink: #1f1d19;
+      --faint: #7c7367;
+      --rule: #cbbda7;
+      --accent: #b95f2b;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: #d9d0c2;
+      color: var(--ink);
+      font-family: "Yu Mincho", "Hiragino Mincho ProN", "Noto Serif JP", Georgia, serif;
+    }
+    .page {
+      max-width: 980px;
+      margin: 32px auto;
+      padding: 56px 62px 64px;
+      background:
+        linear-gradient(rgba(255, 255, 255, 0.34), rgba(255, 255, 255, 0.08)),
+        var(--paper);
+      border: 1px solid #b9aa94;
+      box-shadow: 0 24px 70px rgba(44, 35, 24, 0.22);
+    }
+    .back {
+      display: inline-block;
+      margin: 0 0 26px;
+      color: var(--faint);
+      font-size: 13px;
+      text-decoration: none;
+    }
+    .back:hover { color: var(--accent); }
+    .plate-number {
+      text-align: center;
+      color: var(--faint);
+      font-size: 12px;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+    }
+    h1 {
+      margin: 18px auto 10px;
+      max-width: 760px;
+      text-align: center;
+      font-size: clamp(30px, 5vw, 52px);
+      font-weight: 500;
+      line-height: 1.14;
+      letter-spacing: 0.02em;
+    }
+    .subtitle {
+      max-width: 620px;
+      margin: 0 auto 30px;
+      text-align: center;
+      color: var(--faint);
+      font-size: 15px;
+      line-height: 1.8;
+    }
+    .rule {
+      height: 1px;
+      margin: 24px 0 30px;
+      background: linear-gradient(90deg, transparent, var(--rule), transparent);
+    }
+    .axioms {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 18px;
+      margin: 0 auto 34px;
+      max-width: 760px;
+    }
+    .axiom {
+      display: grid;
+      grid-template-columns: 44px 1fr;
+      gap: 16px;
+      align-items: start;
+    }
+    .mark {
+      color: var(--accent);
+      font-family: Georgia, "Times New Roman", serif;
+      font-size: 12px;
+      letter-spacing: 0.1em;
+      padding-top: 8px;
+      text-transform: uppercase;
+    }
+    .statement {
+      border-left: 1px solid var(--rule);
+      padding-left: 18px;
+    }
+    .statement .math {
+      margin: 0;
+      font-size: 20px;
+      font-family: Georgia, "Times New Roman", serif;
+    }
+    .statement p {
+      margin: 8px 0 0;
+      color: var(--faint);
+      font-size: 14px;
+      line-height: 1.7;
+    }
+    .matrix-section {
+      margin: 38px auto;
+      padding: 28px;
+      border: 1px solid var(--rule);
+      background: rgba(255, 255, 255, 0.22);
+    }
+    .matrix-title {
+      display: flex;
+      justify-content: space-between;
+      gap: 16px;
+      align-items: baseline;
+      margin-bottom: 18px;
+      border-bottom: 1px solid var(--rule);
+      padding-bottom: 10px;
+    }
+    .matrix-title h2 {
+      margin: 0;
+      font-size: 21px;
+      font-weight: 500;
+      letter-spacing: 0.04em;
+    }
+    .matrix-title span {
+      color: var(--faint);
+      font-size: 12px;
+      letter-spacing: 0.08em;
+      white-space: nowrap;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 14px;
+    }
+    th, td {
+      border-bottom: 1px solid rgba(203, 189, 167, 0.82);
+      padding: 11px 10px;
+      text-align: center;
+    }
+    th {
+      color: var(--faint);
+      font-size: 11px;
+      font-weight: 400;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+    }
+    td:first-child, th:first-child { text-align: left; }
+    td:first-child {
+      color: var(--ink);
+      font-style: italic;
+    }
+    .write { color: #8b4a20; font-weight: 700; }
+    .deny { color: #8d2f29; font-weight: 700; }
+    .admin { color: #2f6547; font-weight: 700; }
+    .empty { color: #b7aa98; }
+    .caption {
+      margin: 18px 0 0;
+      color: var(--faint);
+      font-size: 13px;
+      line-height: 1.7;
+    }
+    .closing {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 24px;
+      margin-top: 34px;
+    }
+    .closing-box {
+      border-top: 1px solid var(--rule);
+      padding-top: 16px;
+    }
+    .closing-box .math {
+      font-size: 18px;
+      margin: 0;
+      font-family: Georgia, "Times New Roman", serif;
+    }
+    .closing-box p {
+      margin: 9px 0 0;
+      color: var(--faint);
+      font-size: 13px;
+      line-height: 1.65;
+    }
+    .footer-note {
+      margin-top: 42px;
+      text-align: center;
+      color: var(--faint);
+      font-size: 12px;
+      letter-spacing: 0.08em;
+    }
+    @media (max-width: 720px) {
+      .page {
+        margin: 0;
+        padding: 36px 22px 42px;
+        border-left: 0;
+        border-right: 0;
+      }
+      .axiom {
+        grid-template-columns: 1fr;
+        gap: 6px;
+      }
+      .statement { padding-left: 14px; }
+      .matrix-section {
+        padding: 18px;
+        overflow-x: auto;
+      }
+      table { min-width: 620px; }
+      .closing { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+  <main class="page">
+    <a class="back" href="../../">&larr; orange-wks</a>
+    <div class="plate-number">Plate II / 自己についての覚え書き</div>
+    <h1>自己とは、編集権を配る規則である</h1>
+    <p class="subtitle">The Self as an Access Control Matrix</p>
+
+    <div class="rule"></div>
+
+    <section class="axioms" aria-label="Core notation">
+      <div class="axiom">
+        <div class="mark">I</div>
+        <div class="statement">
+          <div class="math">$$D = P_\phi(W)$$</div>
+          <p>データは世界そのものではない。センサー、事前分布、設計者を通した射影である。</p>
+        </div>
+      </div>
+
+      <div class="axiom">
+        <div class="mark">II</div>
+        <div class="statement">
+          <div class="math">$$Z = C_\theta(D)$$</div>
+          <p>圧縮は、選ばれた差異を保存する。大事な差異だけが残る。</p>
+        </div>
+      </div>
+
+      <div class="axiom">
+        <div class="mark">III</div>
+        <div class="statement">
+          <div class="math">$$O_K(W) = \bigcap_{a \in K} C_a(P_a(W))$$</div>
+          <p>カテゴリ客観とは、そのカテゴリの圧縮器を通してなお残るもの。</p>
+        </div>
+      </div>
+
+      <div class="axiom">
+        <div class="mark">IV</div>
+        <div class="statement">
+          <div class="math">$$S_{t+1} = F(S_t,\, \Pi_B(X_t))$$</div>
+          <p>境界はただの壁ではない。次の状態へ何を通すかを選ぶ。</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="matrix-section" aria-label="Access control matrix">
+      <div class="matrix-title">
+        <h2>編集権限表</h2>
+        <span>誰がどこへ書き込めるか</span>
+      </div>
+
+      <div class="math">$$\mathcal{A} : \text{Source} \times \text{Target} \to \text{Permission}$$</div>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Source</th>
+            <th>習慣</th>
+            <th>価値</th>
+            <th>道徳</th>
+            <th>欲望</th>
+            <th>管理</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>parent</td>
+            <td class="write">write</td>
+            <td class="write">write</td>
+            <td class="empty">-</td>
+            <td class="empty">-</td>
+            <td class="empty">-</td>
+          </tr>
+          <tr>
+            <td>friend</td>
+            <td class="empty">-</td>
+            <td class="write">write</td>
+            <td class="empty">-</td>
+            <td class="empty">-</td>
+            <td class="empty">-</td>
+          </tr>
+          <tr>
+            <td>religion</td>
+            <td class="empty">-</td>
+            <td class="write">write</td>
+            <td class="write">write</td>
+            <td class="empty">-</td>
+            <td class="empty">-</td>
+          </tr>
+          <tr>
+            <td>ad</td>
+            <td class="deny">deny</td>
+            <td class="deny">deny</td>
+            <td class="empty">-</td>
+            <td class="deny">deny</td>
+            <td class="empty">-</td>
+          </tr>
+          <tr>
+            <td>self</td>
+            <td class="admin">admin</td>
+            <td class="admin">admin</td>
+            <td class="admin">admin</td>
+            <td class="admin">admin</td>
+            <td class="admin">admin</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p class="caption">自己とは、編集権そのものではない。誰に、何を、どこまで編集させるかを配る規則である。</p>
+    </section>
+
+    <section class="closing">
+      <div class="closing-box">
+        <div class="math">$$\operatorname{cap}(s) = \{(r,p) \mid \mathcal{A}(s,r)=p\}$$</div>
+        <p>Capability は、主体側から見た権限である。</p>
+      </div>
+      <div class="closing-box">
+        <div class="math">$$\operatorname{acl}(r) = \{(s,p) \mid \mathcal{A}(s,r)=p\}$$</div>
+        <p>ACL は、対象側から見た権限である。</p>
+      </div>
+    </section>
+
+    <div class="footer-note">主観 &rarr; 知性 は、まだ開いたままにしておく。</div>
+  </main>
+</body>
+</html>

--- a/articles/ji-access-control-matrix-ja/meta.json
+++ b/articles/ji-access-control-matrix-ja/meta.json
@@ -1,0 +1,12 @@
+{
+  "tags": [
+    "AI",
+    "哲学",
+    "notation"
+  ],
+  "section": "recent",
+  "title": "自己とは、編集権を配る規則である",
+  "description": "自己を Access Control Matrix として眺めるための、短い数式図版。",
+  "cover": "assets/ogp.jpg",
+  "date": "2026-05-29"
+}

--- a/index.html
+++ b/index.html
@@ -246,6 +246,14 @@
         
       </span>
     </a>
+    <a class="compact-item" href="articles/ji-access-control-matrix-ja/">
+      <span class="compact-date">2026-05-29</span>
+      <span class="compact-title">自己とは、編集権を配る規則である</span>
+      <span class="compact-meta">
+        <span class="card-tag">AI</span><span class="card-tag">哲学</span><span class="card-tag">notation</span>
+        
+      </span>
+    </a>
     <a class="compact-item" href="articles/compression-is-subjective-act/">
       <span class="compact-date">2026-05-24</span>
       <span class="compact-title">「圧縮」は主観的行為である</span>


### PR DESCRIPTION
## Summary
- Add Japanese version of the access control matrix notation plate
- Title: 自己とは、編集権を配る規則である
- Rebuild Portal index and archive

## Verification
- Confirmed article appears in recent list
- Checked generated article metadata/header