### PR TITLE
Enlarge access control plate closing line

### DIFF
--- a/articles/ji-access-control-matrix-ja/index.html
+++ b/articles/ji-access-control-matrix-ja/index.html
@@ -206,7 +206,8 @@
       margin-top: 42px;
       text-align: center;
       color: var(--faint);
-      font-size: 12px;
+      font-size: clamp(17px, 2.6vw, 24px);
+      line-height: 1.45;
       letter-spacing: 0.08em;
     }
     @media (max-width: 720px) {

--- a/articles/ji-access-control-matrix/index.html
+++ b/articles/ji-access-control-matrix/index.html
@@ -224,7 +224,8 @@
       margin-top: 42px;
       text-align: center;
       color: var(--faint);
-      font-size: 12px;
+      font-size: clamp(17px, 2.6vw, 24px);
+      line-height: 1.35;
       letter-spacing: 0.08em;
     }
     @media (max-width: 720px) {


### PR DESCRIPTION
## Summary
- Increase the closing line size on the English and Japanese access-control-matrix plates
- Keep the change scoped to the two article pages