### PR TITLE
Fix OGP image for access control matrix articles

### DIFF
--- a/articles/ji-access-control-matrix-ja/index.html
+++ b/articles/ji-access-control-matrix-ja/index.html
@@ -6,10 +6,10 @@
   <title>自己とは、編集権を配る規則である</title>
   <meta property="og:title" content="自己とは、編集権を配る規則である">
   <meta property="og:description" content="自己を Access Control Matrix として眺めるための、短い数式図版。">
-  <meta property="og:image" content="https://orange-wks.github.io/portal/assets/ogp.jpg">
+  <meta property="og:image" content="https://orange-wks.github.io/portal/articles/ji-access-control-matrix-ja/cover.png">
   <meta property="og:url" content="https://orange-wks.github.io/portal/articles/ji-access-control-matrix-ja/">
   <meta property="og:type" content="article">
-  <meta name="twitter:image" content="https://orange-wks.github.io/portal/assets/ogp.jpg">
+  <meta name="twitter:image" content="https://orange-wks.github.io/portal/articles/ji-access-control-matrix-ja/cover.png">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css">
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js"></script>

--- a/articles/ji-access-control-matrix/index.html
+++ b/articles/ji-access-control-matrix/index.html
@@ -6,10 +6,10 @@
   <title>The Self as an Access Control Matrix</title>
   <meta property="og:title" content="The Self as an Access Control Matrix">
   <meta property="og:description" content="A small notation plate for projection, compression, category objectivity, instinct, boundary, memory, and future self-editing.">
-  <meta property="og:image" content="https://orange-wks.github.io/portal/assets/ogp.jpg">
+  <meta property="og:image" content="https://orange-wks.github.io/portal/articles/ji-access-control-matrix/cover.png">
   <meta property="og:url" content="https://orange-wks.github.io/portal/articles/ji-access-control-matrix/">
   <meta property="og:type" content="article">
-  <meta name="twitter:image" content="https://orange-wks.github.io/portal/assets/ogp.jpg">
+  <meta name="twitter:image" content="https://orange-wks.github.io/portal/articles/ji-access-control-matrix/cover.png">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css">
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js"></script>


### PR DESCRIPTION
## Summary
- Point English and Japanese access-control-matrix article OGP/Twitter image tags to their article cover.png files
- Fixes pages still showing the default portal OGP image when shared

## Verification
- Checked HTML meta tag diffs