### PR TITLE
Add explicit Twitter card metadata

### DIFF
--- a/articles/ji-access-control-matrix-20260531/index.html
+++ b/articles/ji-access-control-matrix-20260531/index.html
@@ -7,9 +7,14 @@
   <meta property="og:title" content="The Self as an Access Control Matrix">
   <meta property="og:description" content="A small notation plate for projection, compression, category objectivity, instinct, boundary, memory, and future self-editing.">
   <meta property="og:image" content="https://orange-wks.github.io/portal/articles/ji-access-control-matrix-20260531/cover.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
   <meta property="og:url" content="https://orange-wks.github.io/portal/articles/ji-access-control-matrix-20260531/">
   <meta property="og:type" content="article">
+  <meta name="twitter:title" content="The Self as an Access Control Matrix">
+  <meta name="twitter:description" content="A small notation plate for projection, compression, category objectivity, instinct, boundary, memory, and future self-editing.">
   <meta name="twitter:image" content="https://orange-wks.github.io/portal/articles/ji-access-control-matrix-20260531/cover.png">
+  <meta name="twitter:image:alt" content="The Self as an Access Control Matrix notation plate">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css">
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js"></script>

--- a/articles/ji-access-control-matrix-ja-20260531/index.html
+++ b/articles/ji-access-control-matrix-ja-20260531/index.html
@@ -7,9 +7,14 @@
   <meta property="og:title" content="自己とは、編集権を配る規則である">
   <meta property="og:description" content="自己を Access Control Matrix として眺めるための、短い数式図版。">
   <meta property="og:image" content="https://orange-wks.github.io/portal/articles/ji-access-control-matrix-ja-20260531/cover.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
   <meta property="og:url" content="https://orange-wks.github.io/portal/articles/ji-access-control-matrix-ja-20260531/">
   <meta property="og:type" content="article">
+  <meta name="twitter:title" content="自己とは、編集権を配る規則である">
+  <meta name="twitter:description" content="自己を Access Control Matrix として眺めるための、短い数式図版。">
   <meta name="twitter:image" content="https://orange-wks.github.io/portal/articles/ji-access-control-matrix-ja-20260531/cover.png">
+  <meta name="twitter:image:alt" content="自己とは、編集権を配る規則である、という数式図版">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css">
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js"></script>


### PR DESCRIPTION
## Summary
- add twitter:title and twitter:description to the access control matrix pages
- add og:image dimensions and twitter:image:alt

## Notes
- intended to make X card image handling less ambiguous