### PR TITLE
Match existing Twitter summary card format

### DIFF
--- a/articles/ji-access-control-matrix-20260531/index.html
+++ b/articles/ji-access-control-matrix-20260531/index.html
@@ -15,7 +15,7 @@
   <meta name="twitter:description" content="A small notation plate for projection, compression, category objectivity, instinct, boundary, memory, and future self-editing.">
   <meta name="twitter:image" content="https://orange-wks.github.io/portal/articles/ji-access-control-matrix-20260531/cover.png">
   <meta name="twitter:image:alt" content="The Self as an Access Control Matrix notation plate">
-  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:card" content="summary">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css">
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js"></script>

--- a/articles/ji-access-control-matrix-ja-20260531/index.html
+++ b/articles/ji-access-control-matrix-ja-20260531/index.html
@@ -15,7 +15,7 @@
   <meta name="twitter:description" content="自己を Access Control Matrix として眺めるための、短い数式図版。">
   <meta name="twitter:image" content="https://orange-wks.github.io/portal/articles/ji-access-control-matrix-ja-20260531/cover.png">
   <meta name="twitter:image:alt" content="自己とは、編集権を配る規則である、という数式図版">
-  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:card" content="summary">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css">
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js"></script>


### PR DESCRIPTION
## Summary
- change the new access control matrix pages from summary_large_image to summary
- keep the explicit title, description, image dimensions, and image alt metadata

## Notes
- matches the Twitter card format used by previous portal articles that preview correctly